### PR TITLE
Megatag split - primarily readability

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/LimelightBotPose.java
+++ b/src/main/java/frc/robot/subsystems/vision/LimelightBotPose.java
@@ -37,17 +37,25 @@ public class LimelightBotPose {
   private static final int OFFSET_TAG_DIST_TO_ROBOT = 5;
   private static final int OFFSET_TAG_AMBIGUITY = 6;
 
-  public LimelightBotPose(double[] botPose, long timestampMicros) {
-    update(botPose, timestampMicros);
+  /**
+   * Create a new LimelightBotPose object, initialized with no data.
+   *
+   * @see #update(TimestampedDoubleArray)'
+   */
+  public LimelightBotPose() {
+    this.botPose = new double[0];
+    this.timestampMicros = 0;
   }
 
+  /**
+   * Update the LimelightBotPose with new data
+   *
+   * @param botPoseData new data from the Limelight; never null
+   */
   public void update(TimestampedDoubleArray botPoseData) {
-    update(botPoseData.value, botPoseData.timestamp);
-  }
-
-  public void update(double[] botPose, long timestampMicros) {
-    this.botPose = Objects.requireNonNullElseGet(botPose, () -> new double[0]);
-    this.timestampMicros = timestampMicros;
+    Objects.requireNonNull(botPoseData, "botPoseData must not be null");
+    this.botPose = botPoseData.value;
+    this.timestampMicros = botPoseData.timestamp;
   }
 
   public Translation2d getTranslation() {

--- a/src/main/java/frc/robot/subsystems/vision/LimelightBotPose.java
+++ b/src/main/java/frc/robot/subsystems/vision/LimelightBotPose.java
@@ -62,6 +62,11 @@ public class LimelightBotPose {
     return new Translation2d(getPoseX(), getPoseY());
   }
 
+  /**
+   * Make sure tags are visible and pose is on-field
+   *
+   * @return true if the pose is valid
+   */
   public boolean isPoseValid() {
     return (getTagCount() > 0
         && isPoseXInBounds(0, Constants.FieldConstants.FIELD_EXTENT_METRES_X)

--- a/src/main/java/frc/robot/subsystems/vision/LimelightPoseEstimate.java
+++ b/src/main/java/frc/robot/subsystems/vision/LimelightPoseEstimate.java
@@ -15,9 +15,9 @@ public class LimelightPoseEstimate implements VisionPoseEstimate {
     MEGATAG2
   }
 
-  private Pose2d pose;
-  private double timestamp;
-  private Matrix<N3, N1> standardDeviations;
+  private final Pose2d pose;
+  private final double timestamp;
+  private final Matrix<N3, N1> standardDeviations;
 
   public LimelightPoseEstimate(Pose2d pose, double timestamp, Matrix<N3, N1> standardDeviations) {
     this.pose = pose;
@@ -38,17 +38,5 @@ public class LimelightPoseEstimate implements VisionPoseEstimate {
   @Override
   public Matrix<N3, N1> getStandardDeviations() {
     return standardDeviations;
-  }
-
-  public void setPose(Pose2d pose) {
-    this.pose = pose;
-  }
-
-  public void setTimestamp(double timestamp) {
-    this.timestamp = timestamp;
-  }
-
-  public void setStandardDeviations(Matrix<N3, N1> standardDeviations) {
-    this.standardDeviations = standardDeviations;
   }
 }

--- a/src/main/java/frc/robot/subsystems/vision/LimelightVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/LimelightVisionSubsystem.java
@@ -82,8 +82,17 @@ public class LimelightVisionSubsystem extends SubsystemBase {
     nikolaBotPoseCache.update(nikolaMegaTag.getAtomic());
     thomasBotPoseCache.update(thomasMegaTag.getAtomic());
 
-    // Lastly, publish the pose estimate to the PoseEstimator
-    updateVisionPose();
+    // Next, publish the pose estimate to the PoseEstimator
+    if (poseUpdatesEnabled && nikolaBotPoseCache.isPoseValid()) {
+      if (megatag2) {
+        swerve.addVisionMeasurement(getMegatag2PoseEstimate());
+      } else {
+        swerve.addVisionMeasurement(getMegatag1PoseEstimate());
+      }
+    }
+
+    // Update telemetry
+    updateTelemetry();
   }
 
   /**
@@ -250,99 +259,82 @@ public class LimelightVisionSubsystem extends SubsystemBase {
   }
 
   /**
-   * Get the pose estimate from the vision system to swerve's odometry
-   *
-   * <p>Logic In This Function:
-   *
-   * <ol>
-   *   <li>Set the orientation of the robot from odometry into the limelight for MegaTag2 to work
-   *   <li>Ensure the latest vision pose data is valid (on field, >=1 tags visible, robot not
-   *       spinning like crazy
-   *   <li>If megatag2 was set, just use the data with recommended standard deviation data.
-   *   <li>If using megatag1:
-   *       <ul>
-   *         <li>Check tag ambiguity - if it's very low (<0.1) it means we've got a high confidence
-   *             set of data, so use low standard deviation.
-   *         <li>If ambiguity is medium (0.1-0.7), use distance from tag to scale standard
-   *             deviations and trust this data as medium confidence.
-   *         <li>If ambiguity is > 0.7, don't use the data at all.
-   *       </ul>
-   * </ol>
+   * Use Megatag2 to create a pose estimate. Just use the data with recommended standard deviation
+   * data.
    */
-  private void updateVisionPose() {
+  private VisionPoseEstimate getMegatag2PoseEstimate() {
+    VisionPoseEstimate visionPoseEstimate =
+        new LimelightPoseEstimate(
+            nikolaBotPoseCache.getPose(),
+            nikolaBotPoseCache.getTimestampSeconds() - nikolaBotPoseCache.getTotalLatencySeconds(),
+            MEGATAG2_STDDEV);
+    Telemetry.vision.poseConfidence = LimelightPoseEstimate.PoseConfidence.MEGATAG2;
+    Telemetry.vision.tagAmbiguity = Double.MIN_VALUE;
+    return visionPoseEstimate;
+  }
 
-    VisionPoseEstimate visionPoseEstimate = null;
-
-    // Get the current pose delta
-    double compareDistance = -1;
-    double compareHeading = -1;
+  /**
+   * Try to use Megatag1 data to create a pose estimate.
+   *
+   * <ul>
+   *   <li>Check tag ambiguity - if it's very low (<0.1) it means we've got a high confidence set of
+   *       data, so use low standard deviation.
+   *   <li>If ambiguity is medium (0.1-0.7), use distance from tag to scale standard deviations and
+   *       trust this data as medium confidence.
+   *   <li>If ambiguity is > 0.7, don't use the data at all.
+   * </ul>
+   *
+   * @return
+   */
+  private VisionPoseEstimate getMegatag1PoseEstimate() {
     double tagAmbiguity = nikolaBotPoseCache.getTagAmbiguity(0);
-    Pose2d odometryPose = swerve.getPose();
-    double yaw = swerve.getYaw();
+    Telemetry.vision.tagAmbiguity = tagAmbiguity;
 
-    LimelightPoseEstimate.PoseConfidence poseConfidence = LimelightPoseEstimate.PoseConfidence.NONE;
+    /* MegaTag 1 Handling - only is Ambiguity < 0.7 */
+    if (tagAmbiguity < maxAmbiguity) {
 
-    // Make sure tags are visible and pose is on-field
-    if (nikolaBotPoseCache.isPoseValid()) {
+      if (tagAmbiguity < highQualityAmbiguity || DriverStation.isDisabled()) {
+        // If the ambiguity is very low (< 0.1) or DriverStation disabled, high confidence pose
+        // update
+        Telemetry.vision.poseConfidence = LimelightPoseEstimate.PoseConfidence.MEGATAG1_HIGH;
+        return new LimelightPoseEstimate(
+            nikolaBotPoseCache.getPose(),
+            nikolaBotPoseCache.getTimestampSeconds(),
+            MEGATAG1_STDDEV);
 
-      if (megatag2) {
-        /* MegaTag 2 Handling */
-        poseConfidence = LimelightPoseEstimate.PoseConfidence.MEGATAG2;
-        visionPoseEstimate =
-            new LimelightPoseEstimate(
-                nikolaBotPoseCache.getPose(),
-                nikolaBotPoseCache.getTimestampSeconds()
-                    - nikolaBotPoseCache.getTotalLatencySeconds(),
-                MEGATAG2_STDDEV);
-        /* End MegaTag 2 Handling */
-      } else if (tagAmbiguity < maxAmbiguity) {
-        /* MegaTag 1 Handling - only is Ambiguity < 0.7 */
-
-        if (tagAmbiguity < highQualityAmbiguity || DriverStation.isDisabled()) {
-          // If the ambiguity is very low (< 0.1) or DriverStation disabled, high confidence pose
-          // update
-          poseConfidence = LimelightPoseEstimate.PoseConfidence.MEGATAG1_HIGH;
-          visionPoseEstimate =
-              new LimelightPoseEstimate(
-                  nikolaBotPoseCache.getPose(),
-                  nikolaBotPoseCache.getTimestampSeconds(),
-                  MEGATAG1_STDDEV);
-
-        } else {
-          // For medium Ambiguity, only use it if we're within 0.5m.  Scale standard deviation by
-          // distance.
-          compareDistance =
-              nikolaBotPoseCache
-                  .getPose()
-                  .getTranslation()
-                  .getDistance(odometryPose.getTranslation());
-          if (compareDistance < maxVisposDeltaDistanceMetres) {
-            poseConfidence = LimelightPoseEstimate.PoseConfidence.MEGATAG1_MED;
-            double stdDevRatio = Math.pow(nikolaBotPoseCache.getTagDistToRobot(0), 2) / 2;
-            Matrix<N3, N1> deviations = VecBuilder.fill(stdDevRatio, stdDevRatio, stdDevRatio * 5);
-            visionPoseEstimate =
-                new LimelightPoseEstimate(
-                    nikolaBotPoseCache.getPose(),
-                    nikolaBotPoseCache.getTimestampSeconds(),
-                    deviations);
-          }
+      } else {
+        // For medium Ambiguity, only use it if we're within 0.5m.  Scale standard deviation by
+        // distance.
+        double compareDistance =
+            nikolaBotPoseCache
+                .getPose()
+                .getTranslation()
+                .getDistance(swerve.getPose().getTranslation());
+        if (compareDistance < maxVisposDeltaDistanceMetres) {
+          Telemetry.vision.poseConfidence = LimelightPoseEstimate.PoseConfidence.MEGATAG1_MED;
+          double stdDevRatio = Math.pow(nikolaBotPoseCache.getTagDistToRobot(0), 2) / 2;
+          Matrix<N3, N1> deviations = VecBuilder.fill(stdDevRatio, stdDevRatio, stdDevRatio * 5);
+          return new LimelightPoseEstimate(
+              nikolaBotPoseCache.getPose(), nikolaBotPoseCache.getTimestampSeconds(), deviations);
         }
-        /* End MegaTag 1 Handling */
       }
     }
+    return null;
+  }
 
-    // Telemetry Handling
+  private void updateTelemetry() {
     if (Telemetry.vision.telemetryLevel == VisionTelemetryLevel.REGULAR
         || Telemetry.vision.telemetryLevel == VisionTelemetryLevel.VERBOSE) {
 
-      compareDistance =
+      Pose2d odometryPose = swerve.getPose();
+      double yaw = swerve.getYaw();
+
+      double compareDistance =
           nikolaBotPoseCache.getPose().getTranslation().getDistance(odometryPose.getTranslation());
-      compareHeading =
+      double compareHeading =
           nikolaBotPoseCache.getPose().getRotation().getDegrees()
               - odometryPose.getRotation().getDegrees();
 
-      Telemetry.vision.tagAmbiguity = tagAmbiguity;
-      Telemetry.vision.poseConfidence = poseConfidence;
       Telemetry.vision.poseDeltaMetres = compareDistance;
       Telemetry.vision.headingDeltaDegrees = compareHeading;
       Telemetry.vision.poseMetresX = odometryPose.getX();
@@ -369,10 +361,6 @@ public class LimelightVisionSubsystem extends SubsystemBase {
       Telemetry.vision.tomTx = thomasBotPoseCache.getTagTxnc(0);
       Telemetry.vision.tomDistanceToRobot = thomasBotPoseCache.getTagDistToRobot(0);
       Telemetry.vision.tomDistanceToCam = thomasBotPoseCache.getTagDistToCamera(0);
-    }
-
-    if (poseUpdatesEnabled && visionPoseEstimate != null) {
-      swerve.addVisionMeasurement(visionPoseEstimate);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/vision/LimelightVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/LimelightVisionSubsystem.java
@@ -17,30 +17,23 @@ import frc.robot.telemetry.Telemetry;
 
 public class LimelightVisionSubsystem extends SubsystemBase {
 
-  private final NetworkTable nikolaVision =
-      NetworkTableInstance.getDefault().getTable("limelight-nikola");
-  private final NetworkTable thomasVision =
-      NetworkTableInstance.getDefault().getTable("limelight-thomas");
+  // Standard Deviations Used for most of the Pose Updates
+  private static final Matrix<N3, N1> MEGATAG1_STDDEV = VecBuilder.fill(0.01, 0.01, 0.05);
+  private static final Matrix<N3, N1> MEGATAG2_STDDEV = VecBuilder.fill(0.06, 0.06, 9999999);
 
-  private final DoubleArrayPublisher nikolaRobotOrientation =
-      nikolaVision.getDoubleArrayTopic("robot_orientation_set").publish();
-  private final DoubleArrayPublisher thomasRobotOrientation =
-      thomasVision.getDoubleArrayTopic("robot_orientation_set").publish();
+  // Orientation publishers
+  private final DoubleArrayPublisher nikolaRobotOrientation;
+  private final DoubleArrayPublisher thomasRobotOrientation;
 
   // MegaTags
   private final DoubleArraySubscriber nikolaMegaTag;
   private final DoubleArraySubscriber thomasMegaTag;
 
-  // Standard Deviations Used for most of the Pose Updates
-  private final Matrix<N3, N1> poseDeviation;
-
   // These hold the data from the limelights, updated every periodic()
-  private final LimelightBotPose nikolaBotPoseCache = new LimelightBotPose(null, 0);
-  private final LimelightBotPose thomasBotPoseCache = new LimelightBotPose(null, 0);
+  private final LimelightBotPose nikolaBotPoseCache = new LimelightBotPose();
+  private final LimelightBotPose thomasBotPoseCache = new LimelightBotPose();
 
   private final SwerveSubsystem swerve;
-  private final double fieldExtentMetresX;
-  private final double fieldExtentMetresY;
   private final double maxAmbiguity;
   private final double highQualityAmbiguity;
   private final double maxVisposDeltaDistanceMetres;
@@ -49,8 +42,6 @@ public class LimelightVisionSubsystem extends SubsystemBase {
   private boolean poseUpdatesEnabled = true;
 
   public LimelightVisionSubsystem(VisionConfig visionConfig, SwerveSubsystem swerve) {
-    this.fieldExtentMetresX = visionConfig.fieldExtentMetresX();
-    this.fieldExtentMetresY = visionConfig.fieldExtentMetresY();
     this.maxAmbiguity = visionConfig.maxAmbiguity();
     this.highQualityAmbiguity = visionConfig.highQualityAmbiguity();
     this.maxVisposDeltaDistanceMetres = visionConfig.maxVisposeDeltaDistanceMetres();
@@ -58,24 +49,26 @@ public class LimelightVisionSubsystem extends SubsystemBase {
     Telemetry.vision.telemetryLevel = visionConfig.telemetryLevel();
     this.swerve = swerve;
 
+    final NetworkTable nikola = NetworkTableInstance.getDefault().getTable("limelight-nikola");
+    final NetworkTable thomas = NetworkTableInstance.getDefault().getTable("limelight-thomas");
+
+    nikolaRobotOrientation = nikola.getDoubleArrayTopic("robot_orientation_set").publish();
+    thomasRobotOrientation = thomas.getDoubleArrayTopic("robot_orientation_set").publish();
+
     // Initialize the NT subscribers for whichever of MT1/2 is used
     if (megatag2) {
-      nikolaMegaTag =
-          nikolaVision.getDoubleArrayTopic("botpose_orb_wpiblue").subscribe(new double[0]);
-      thomasMegaTag =
-          thomasVision.getDoubleArrayTopic("botpose_orb_wpiblue").subscribe(new double[0]);
-      poseDeviation = VecBuilder.fill(0.06, 0.06, 9999999);
+      nikolaMegaTag = nikola.getDoubleArrayTopic("botpose_orb_wpiblue").subscribe(new double[0]);
+      thomasMegaTag = thomas.getDoubleArrayTopic("botpose_orb_wpiblue").subscribe(new double[0]);
     } else {
-      nikolaMegaTag = nikolaVision.getDoubleArrayTopic("botpose_wpiblue").subscribe(new double[0]);
-      thomasMegaTag = thomasVision.getDoubleArrayTopic("botpose_wpiblue").subscribe(new double[0]);
-      poseDeviation = VecBuilder.fill(0.01, 0.01, 0.05);
+      nikolaMegaTag = nikola.getDoubleArrayTopic("botpose_wpiblue").subscribe(new double[0]);
+      thomasMegaTag = thomas.getDoubleArrayTopic("botpose_wpiblue").subscribe(new double[0]);
     }
 
     // inputs/configs
-    nikolaVision.getEntry("pipeline").setNumber(visionConfig.pipelineAprilTagDetect());
-    nikolaVision.getEntry("camMode").setNumber(visionConfig.camModeVision());
-    thomasVision.getEntry("pipeline").setNumber(visionConfig.pipelineAprilTagDetect());
-    thomasVision.getEntry("camMode").setNumber(visionConfig.camModeVision());
+    nikola.getEntry("pipeline").setNumber(visionConfig.pipelineAprilTagDetect());
+    nikola.getEntry("camMode").setNumber(visionConfig.camModeVision());
+    thomas.getEntry("pipeline").setNumber(visionConfig.pipelineAprilTagDetect());
+    thomas.getEntry("camMode").setNumber(visionConfig.camModeVision());
   }
 
   @Override
@@ -300,7 +293,7 @@ public class LimelightVisionSubsystem extends SubsystemBase {
                 nikolaBotPoseCache.getPose(),
                 nikolaBotPoseCache.getTimestampSeconds()
                     - nikolaBotPoseCache.getTotalLatencySeconds(),
-                poseDeviation);
+                MEGATAG2_STDDEV);
         /* End MegaTag 2 Handling */
       } else if (tagAmbiguity < maxAmbiguity) {
         /* MegaTag 1 Handling - only is Ambiguity < 0.7 */
@@ -313,7 +306,7 @@ public class LimelightVisionSubsystem extends SubsystemBase {
               new LimelightPoseEstimate(
                   nikolaBotPoseCache.getPose(),
                   nikolaBotPoseCache.getTimestampSeconds(),
-                  poseDeviation);
+                  MEGATAG1_STDDEV);
 
         } else {
           // For medium Ambiguity, only use it if we're within 0.5m.  Scale standard deviation by


### PR DESCRIPTION
Further to conversations between Tony and Jeff, this PR attempts to improve readability of the Megaton processing logic.

Split Megatag1 and Megatag2 processing out into their own functions, in order to emphasize that only one or the other mode will be operational at a time (based on vision config).

NOTE:
- preserves all previous comments
- performance should match, with the following exceptions
--- makes 1 additional call to getYaw and getPose, but both of these are cached in swerve (trivial improvement when in use)
--- all pose calculations avoided if poseUpdatesEnabled is disabled (significant improvement if pose disabled)